### PR TITLE
Fix broken link to "Add your company"

### DIFF
--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -18,7 +18,7 @@ class Users extends React.Component {
       return null;
     }
 
-    const editUrl = `${siteConfig.repoUrl}/edit/master/website/siteConfig.js`;
+    const editUrl = `${siteConfig.repoUrl}/edit/source/website/siteConfig.js`;
     const showcase = siteConfig.users.map(user => (
       <a href={user.infoLink} key={user.infoLink}>
         <img src={user.image} alt={user.caption} title={user.caption} />

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -104,7 +104,7 @@ const siteConfig = {
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
-  //   repoUrl: 'https://github.com/facebook/test-site',
+  repoUrl: 'https://github.com/podium-lib/podium-lib.github.io',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Hi! Noticed that this "add your company" link:

![image](https://user-images.githubusercontent.com/5826695/59923393-9d9bff00-9433-11e9-920e-4b3604055713.png)


leads to:
`undefined/edit/master/website/siteConfig.js`

So made a quick edit :)