### PR TITLE
Remove reference to prefix on .js() and .css() methods

### DIFF
--- a/docs/api/layout.md
+++ b/docs/api/layout.md
@@ -542,10 +542,9 @@ assets.
 #### options
 
 | option | type      | default   | required | details                                                                                     |
-| ------ | --------- | --------- | -------- | ------------------------------------------------------------------------------------------- |
-| value  | `string`  |           | &check;  | Relative or absolute URL to the JavaScript asset                                            |
-| prefix | `boolean` | `false`   |          | If the `pathname` defined on the constructor should be applied, if relative, to the `value` |
-| type   | `string`  | `default` |          | What type of JavaScript (eg. esm, default, cjs)                                             |
+| ------ | --------- | --------- | -------- | ------------------------------------------------ |
+| value  | `string`  |           | &check;  | Relative or absolute URL to the JavaScript asset |
+| type   | `string`  | `default` |          | What type of JavaScript (eg. esm, default, cjs)  |
 
 ##### value
 
@@ -675,24 +674,6 @@ const layout = new Layout({
 layout.js({ value: 'http://cdn.mysite.com/assets/js/e7rfg76.js' });
 ```
 
-##### prefix
-
-Specify whether the method should prefix the return value with the value for
-`pathname` set in the constructor.
-
-Return the full pathname, `/foo/assets/main.js`, to the JavaScript assets:
-
-```js
-const layout = new Layout({
-    name: 'myLayout',
-    pathname: '/foo',
-});
-
-layout.js({ value: '/assets/main.js', prefix: true });
-```
-
-Prefix will be ignored if the returned value is an absolute URL.
-
 ##### type
 
 Sets the type for the script which is set. If not set, `default` will be used.
@@ -711,7 +692,6 @@ tags or when optimizing JavaScript assets with a bundler.
 
 ### .css(options|[options])
 
-
 Set relative or absolute URLs to Cascading Style Sheets (CSS) assets for the
 layout.
 
@@ -724,10 +704,9 @@ assets.
 
 #### options
 
-| option | type      | default | required | details                                                                                          |
-| ------ | --------- | ------- | -------- | ------------------------------------------------------------------------------------------------ |
-| value  | `string`  |         | &check;  | Relative or absolute URL to the CSS asset                                                        |
-| prefix | `boolean` | `false` |          | Whether the `pathname` defined on the constructor should be applied, if relative, to the `value` |
+| option | type      | default | required | details                                   |
+| ------ | --------- | ------- | -------- | ----------------------------------------- |
+| value  | `string`  |         | &check;  | Relative or absolute URL to the CSS asset |
 
 ##### value
 
@@ -856,24 +835,6 @@ const layout = new Layout({
 
 layout.css({ value: 'http://cdn.mysite.com/assets/css/3ru39ur.css' });
 ```
-
-##### prefix
-
-Sets whether the method should prefix the return value with the `pathname` value
-that was set in the constructor.
-
-Returns the full pathname (`/foo/assets/main.css`) to the CSS asset being added:
-
-```js
-const layout = new Layout({
-    name: 'myLayout',
-    pathname: '/foo',
-});
-
-layout.css({ value: '/assets/main.css', prefix: true });
-```
-
-Prefix will be ignored if the returned value is an absolute URL
 
 ### .pathname()
 

--- a/docs/api/podlet.md
+++ b/docs/api/podlet.md
@@ -1184,11 +1184,10 @@ assets.
 
 #### options
 
-| option | type      | default   | required | details                                                                                     |
-| ------ | --------- | --------- | -------- | ------------------------------------------------------------------------------------------- |
-| value  | `string`  |           | &check;  | Relative or absolute URL to the JavaScript asset                                            |
-| prefix | `boolean` | `false`   |          | If the `pathname` defined in the constructor should be applied, if relative, to the `value` |
-| type   | `string`  | `default` |          | What type of JavaScript                                                                     |
+| option | type      | default   | required | details                                          |
+| ------ | --------- | --------- | -------- | ------------------------------------------------ |
+| value  | `string`  |           | &check;  | Relative or absolute URL to the JavaScript asset |
+| type   | `string`  | `default` |          | What type of JavaScript (eg. esm, default, cjs)  |
 
 ##### value
 
@@ -1373,25 +1372,6 @@ const podlet = new Podlet({
 podlet.js({ value: 'http://cdn.mysite.com/assets/js/e7rfg76.js' });
 ```
 
-##### prefix
-
-Specify whether the method should prefix the return value with the value for
-`pathname` that was set in the constructor.
-
-Return the full pathname, `/foo/assets/main.js`, to the JavaScript assets:
-
-```js
-const podlet = new Podlet({
-    name: 'myPodlet',
-    version: '1.0.0',
-    pathname: '/foo',
-});
-
-podlet.js({ value: '/assets/main.js', prefix: true });
-```
-
-Prefix will be ignored if the returned value is an absolute URL.
-
 ##### type
 
 Set the type of script which is set. If not set, `default` will be used.
@@ -1423,10 +1403,9 @@ assets.
 
 #### options
 
-| option | type      | default | required | details                                                                                     |
-| ------ | --------- | ------- | -------- | ------------------------------------------------------------------------------------------- |
-| value  | `string`  |         | &check;  | Relative or absolute URL to the CSS asset                                                   |
-| prefix | `boolean` | `false` |          | If the `pathname` defined in the constructor should be applied, if relative, to the `value` |
+| option | type      | default | required | details                                   |
+| ------ | --------- | ------- | -------- | ----------------------------------------- |
+| value  | `string`  |         | &check;  | Relative or absolute URL to the CSS asset |
 
 ##### value
 
@@ -1610,25 +1589,6 @@ const podlet = new Podlet({
 
 podlet.css({ value: 'http://cdn.mysite.com/assets/css/3ru39ur.css' });
 ```
-
-##### prefix
-
-Sets whether the method should prefix the return value with the value for
-`pathname` set in the constructor.
-
-Returns the full pathname (`/foo/assets/main.css`) to the CSS assets:
-
-```js
-const podlet = new Podlet({
-    name: 'myPodlet',
-    version: '1.0.0',
-    pathname: '/foo',
-});
-
-podlet.css({ value: '/assets/main.css', prefix: true });
-```
-
-Prefix will be ignored if the returned value is an absolute URL.
 
 ### .proxy({ target, name })
 


### PR DESCRIPTION
In version V3 the `.js()` and `.css()` methods would set only one asset file. Due to this, these methods would return the value which was passed in and if called with no arguments they would return the string value kept by the instance. This was mainly done as a handy way to get the path to assets for use in a http route like so:

```js
podlet.js({ value: '/assets/main.js' });
app.get(podlet.js(), (req, res) => { ... });
```

In V4 this have changed so its now possible to set multiple asset files by these methods. Internally this is kept as an array and not a single value any more.

Due to this change these methods has deprecated the feature of returning a value. Return value will be removed in V5 and should not be used in V4. As a result of this the `prefix` property to these methods have no function any more.

This removes documentation of the `prefix` property for these methods plus any reference to these methods returning a value.