### PR TITLE
docs: add documentation for the strategy and scope asset properties

### DIFF
--- a/docs/api/assets.md
+++ b/docs/api/assets.md
@@ -393,6 +393,39 @@ const server = http.createServer(async (req, res) => {
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
+### Asset scope
+
+An optional `scope` property can be used to tell the layout client when to include certain assets and when to exclude them.
+In the podlet you can add this property to your assets and the layout client will automatically filter the assets according to response type.
+
+Possible `scope` values are:
+
+- `content` - only include an asset with this scope when the podlet's content route response is successful and the podium client does not fallback.
+- `fallback` - only include an asset with this scope when the podlet's content route response is unsuccessful and the podium client does fallback.
+- `all` - always include an asset with this scope
+- no scope provided - always include an asset with no scope
+
+You can provide scopes for your assets using the `podlet.js` and `podlet.css` methods in your podlets.
+
+```js
+podlet.js([
+  { value: "https://assets.com/foo/bar/baz.js", scope: "content" },
+  { value: "https://assets.com/foo/bar/baz.js", scope: "fallback" },
+]);
+```
+
+### Asset strategy
+
+An optional `strategy` property can be used to tell the document template about how to load your assets and in which order. In the podlet, you can add this property to your assets and then make use of it inside your document template (this is taken care of for you if you use the default document template).
+
+Possible `strategy` values are:
+
+- `beforeInteractive` - load this asset early. This asset should be loaded as part of the critical render path (CRP) or could be used to perform hydration type tasks.
+- `afterInteractive` - load this asset as soon as the page becomes interactive. Most scripts fall into this category. 
+- `lazy` - lazy load the asset after everything else on the page is ready. Good for tracking scripts that are non essential for the user experience of the page.
+
+A [document template](document.md) can then make use of these values. See [Customising a document template](document.md#asset-loading-strategy) for more information.
+
 ## AssetCSS
 
 An `AssetCSS` instance holds information about a Cascading Style Sheet related
@@ -402,18 +435,20 @@ to a podlet or layout.
 
 An `AssetCSS` instance has the following properties:
 
-| property    | type      | getter  | setter  | default      | details                                                      |
-| ----------- | --------- | ------- | ------- | ------------ | ------------------------------------------------------------ |
-| value       | `string`  | &check; |         | `''`         | Relative or absolute URL to the CSS asset                    |
-| href        | `string`  | &check; |         | `''`         | Alias for the `value` property                               |
-| crossorigin | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element |
-| disabled    | `boolean` | &check; | &check; | `false`      | Correlates to the same attribute on an HTML `<link>` element |
-| hreflang    | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element |
-| title       | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element |
-| media       | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element |
-| type        | `string`  | &check; | &check; | `text/css`   | Correlates to the same attribute on an HTML `<link>` element |
-| rel         | `string`  | &check; | &check; | `stylesheet` | Correlates to the same attribute on an HTML `<link>` element |
-| as          | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element |
+| property    | type      | getter  | setter  | default      | details                                                                                                                                                                             |
+| ----------- | --------- | ------- | ------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| value       | `string`  | &check; |         | `''`         | Relative or absolute URL to the CSS asset                                                                                                                                           |
+| href        | `string`  | &check; |         | `''`         | Alias for the `value` property                                                                                                                                                      |
+| crossorigin | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| disabled    | `boolean` | &check; | &check; | `false`      | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| hreflang    | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| title       | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| media       | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| type        | `string`  | &check; | &check; | `text/css`   | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| rel         | `string`  | &check; | &check; | `stylesheet` | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| as          | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<link>` element                                                                                                                        |
+| strategy    | `string`  | &check; | &check; | `undefined`  | Strategy hint for document templates. Possible values are `lazy`, `beforeInteractive` and `afterInteractive`                                                                        |
+| scope       | `string`  | &check; | &check; | `undefined`  | Asset scope used by the Podium client to filter assets depending on podlet response type (`content` or `fallback`). Possible values are `content`, `fallback`, `all` or `undefined` |
 
 ## Methods
 
@@ -437,17 +472,19 @@ client side assets.
 
 An `AssetJS` instance has the following properties:
 
-| property       | type      | getter  | setter  | default      | details                                                        |
-| -------------- | --------- | ------- | ------- | ------------ | -------------------------------------------------------------- |
-| value          | `string`  | &check; |         | `''`         | Relative or absolute URL to the CSS asset                      |
-| src            | `string`  | &check; |         | `''`         | Alias for the `value` property                                 |
-| referrerpolicy | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<script>` element |
-| crossorigin    | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<script>` element |
-| integrity      | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<script>` element |
-| nomodule       | `boolean` | &check; | &check; | `false`      | Correlates to the same attribute on an HTML `<script>` element |
-| async          | `boolean` | &check; | &check; | `false`      | Correlates to the same attribute on an HTML `<script>` element |
-| defer          | `boolean` | &check; | &check; | `false`      | Correlates to the same attribute on an HTML `<script>` element |
-| type           | `string`  | &check; | &check; | `undefined`  | Correlates to the same attribute on an HTML `<script>` element |
+| property       | type      | getter  | setter  | default     | details                                                                                                                                                                             |
+| -------------- | --------- | ------- | ------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| value          | `string`  | &check; |         | `''`        | Relative or absolute URL to the CSS asset                                                                                                                                           |
+| src            | `string`  | &check; |         | `''`        | Alias for the `value` property                                                                                                                                                      |
+| referrerpolicy | `string`  | &check; | &check; | `undefined` | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| crossorigin    | `string`  | &check; | &check; | `undefined` | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| integrity      | `string`  | &check; | &check; | `undefined` | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| nomodule       | `boolean` | &check; | &check; | `false`     | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| async          | `boolean` | &check; | &check; | `false`     | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| defer          | `boolean` | &check; | &check; | `false`     | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| type           | `string`  | &check; | &check; | `undefined` | Correlates to the same attribute on an HTML `<script>` element                                                                                                                      |
+| strategy       | `string`  | &check; | &check; | `undefined` | Strategy hint for document templates. Possible values are `lazy`, `beforeInteractive` and `afterInteractive`                                                                        |
+| scope          | `string`  | &check; | &check; | `undefined` | Asset scope used by the Podium client to filter assets depending on podlet response type (`content` or `fallback`). Possible values are `content`, `fallback`, `all` or `undefined` |
 
 ## Methods
 

--- a/docs/api/document.md
+++ b/docs/api/document.md
@@ -227,6 +227,35 @@ layout.view((incoming, body, head) => `<!doctype html>
 );
 ```
 
+### Asset loading Strategy
+
+If the podlet's assets contain the `strategy` property, the document template can use this value to determine how and where to load the assets provided.
+
+```js
+const utils = require('@podium/utils');
+
+[ ... ]
+
+layout.view((incoming, body, head) => `<!doctype html>
+<html lang="${incoming.context.locale}">
+    <head>
+        <meta charset="${incoming.view.encoding}">
+        ${incoming.css.map(utils.buildLinkElement).join('\n')}
+        ${incoming.js.filter({ strategy } => strategy === "beforeInteractive").map(utils.buildScriptElement).join('\n')}
+        <title>${incoming.view.title}</title>
+        ${head}
+    </head>
+    <body>
+        ${body}
+        ${incoming.js.filter({ strategy } => strategy === "afterInteractive").map(utils.buildScriptElement).join('\n')}
+        ${incoming.js.filter({ strategy } => strategy === "lazy").map({ href } => `<script type="module">import("${href}")</script>`).join('\n')}
+    </body>
+</html>`;
+);
+```
+
+See [Asset strategy](assets.md#asset-strategy) for additional details.
+
 ## template(HttpIncoming, fragment, [args])
 
 A document template is implemented using a plain JavaScript function that

--- a/docs/layout/assets.md
+++ b/docs/layout/assets.md
@@ -7,7 +7,7 @@ One of the key challenges when using micro-frontend systems like Podium is how t
 
 In the Podium world, a podlet may need to ship with client side JavaScript and/or CSS and when a layout consumes that podlet, it will also need to consume the podlet's JavaScript and/or CSS.
 
-Podium itself does not provide support for asset related tasks such as bundling or minification but we are currently iterating over better general solutions to these problems which will be published and documented as soon as they are ready.
+Podium itself does not provide support for asset related tasks such as bundling or minification but we maintain another project aimed at solving some of the more challenging asset related issues one typically encounters in microfrontend apps. See [eik.dev](https://eik.dev) for more information.
 
 While there are many ways to do so, the following examples illustrate a couple of possibilities for how you might tackle the asset problem currently. Both examples shown here share the same set of challenges:
 


### PR DESCRIPTION
Documents the strategy and scope properties added in these PRs:

* https://github.com/podium-lib/schemas/pull/201
* https://github.com/podium-lib/client/pull/331
* https://github.com/podium-lib/utils/pull/212