### PR TITLE
Update layout proxy timeout default to actual default

### DIFF
--- a/docs/api/layout.md
+++ b/docs/api/layout.md
@@ -582,7 +582,7 @@ Options to be passed on to the proxy.
 | option  | type     | default           | required | details                                                                                                |
 | ------- | -------- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | prefix  | `string` | `podium-resource` |          | Prefix used to namespace the proxy so that it's isolated from other routes in the HTTP server          |
-| timeout | `number` | `6000`            |          | Default value, in milliseconds, for how long a request should wait before the connection is terminated |
+| timeout | `number` | `20000`            |          | Default value, in milliseconds, for how long a request should wait before the connection is terminated |
 
 Example of setting the `timeout` on the proxy to 30 seconds:
 


### PR DESCRIPTION
Based on what I've seen, the actual default is 20000ms

Proxy default constructor value: https://github.com/podium-lib/proxy/blob/5ecf6ea86c02bd4988eb0a9c01f337a06028ed66/lib/proxy.js#L36C9-L36C16

Layout instantiation: https://github.com/podium-lib/layout/blob/680d18db780c39a07c235e831ade68066be38f2d/lib/layout.js#L266